### PR TITLE
Prevent the tab status from being saved while browsing

### DIFF
--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -18,7 +18,9 @@ fun App() {
 
     MaterialTheme {
 
-        TabNavigator(tab = HomeTab,
+        TabNavigator(
+            tab = HomeTab,
+            disposeSteps = true,
             tabDisposable = {
 
                 TabDisposable(
@@ -33,6 +35,7 @@ fun App() {
                 })
             }, bottomBar = {
                 BottomNavigation {
+
                     tabs.forEach { tab ->
                         TabNavigationItem(tab)
                     }

--- a/composeApp/src/commonMain/kotlin/utils/TabNavigator.kt
+++ b/composeApp/src/commonMain/kotlin/utils/TabNavigator.kt
@@ -1,0 +1,80 @@
+package cafe.adriel.voyager.navigator.tab
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+import cafe.adriel.voyager.core.annotation.InternalVoyagerApi
+import cafe.adriel.voyager.core.lifecycle.DisposableEffectIgnoringConfiguration
+import cafe.adriel.voyager.navigator.Navigator
+import cafe.adriel.voyager.navigator.NavigatorDisposeBehavior
+import cafe.adriel.voyager.navigator.compositionUniqueId
+import cafe.adriel.voyager.navigator.tab.CurrentTab
+import cafe.adriel.voyager.navigator.tab.Tab
+
+typealias TabNavigatorContent = @Composable (tabNavigator: TabNavigator) -> Unit
+
+val LocalTabNavigator: ProvidableCompositionLocal<TabNavigator> =
+    staticCompositionLocalOf { error("TabNavigator not initialized") }
+
+@OptIn(InternalVoyagerApi::class)
+@Composable
+fun TabNavigator(
+    tab: Tab,
+    disposeNestedNavigators: Boolean = false,
+    disposeSteps: Boolean = false,
+    tabDisposable: (@Composable (TabNavigator) -> Unit)? = null,
+    key: String = compositionUniqueId(),
+    content: TabNavigatorContent = { CurrentTab() }
+) {
+    Navigator(
+        screen = tab,
+        disposeBehavior = NavigatorDisposeBehavior(
+            disposeNestedNavigators = disposeNestedNavigators,
+            disposeSteps = disposeSteps
+        ),
+        onBackPressed = null,
+        key = key
+    ) { navigator ->
+        val tabNavigator = remember(navigator) {
+            TabNavigator(navigator)
+        }
+
+        tabDisposable?.invoke(tabNavigator)
+
+        CompositionLocalProvider(LocalTabNavigator provides tabNavigator) {
+            content(tabNavigator)
+        }
+    }
+}
+
+@OptIn(InternalVoyagerApi::class)
+@Composable
+fun TabDisposable(navigator: TabNavigator, tabs: List<Tab>) {
+    DisposableEffectIgnoringConfiguration(Unit) {
+        onDispose {
+            tabs.forEach {
+                navigator.navigator.dispose(it)
+            }
+        }
+    }
+}
+
+class TabNavigator internal constructor(
+    internal val navigator: Navigator
+) {
+
+    var current: Tab
+        get() = navigator.lastItem as Tab
+        set(tab) = navigator.replaceAll(tab)
+
+    @Composable
+    fun saveableState(
+        key: String,
+        tab: Tab = current,
+        content: @Composable () -> Unit
+    ) {
+        navigator.saveableState(key, tab, content = content)
+    }
+}


### PR DESCRIPTION
When you navigate in tabs and within a tab you navigate to a screen, this screen is saved when you return to the tab, the original TabNavigator has been overwritten to set the disposeSteps parameter as optional and set it to true.

This way, the state of the last screen saved in the tab is no longer saved, but the original tab is recreated.